### PR TITLE
Feature/#16 layout 컴포넌트 추가, 다음버튼 활성화

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -3,12 +3,15 @@ import { ThemeProvider } from "styled-components";
 import { RouterProvider } from "react-router-dom";
 import theme from "./styles/theme";
 import router from "./router";
+import Layout from "./components/Layout";
 
 function App() {
   return (
     <ThemeProvider theme={theme}>
       <GlobalStyle />
-      <RouterProvider router={router} />
+      <Layout>
+        <RouterProvider router={router} />
+      </Layout>
     </ThemeProvider>
   );
 }

--- a/src/components/Layout.jsx
+++ b/src/components/Layout.jsx
@@ -1,0 +1,10 @@
+import styled from "styled-components";
+
+const Layout = styled.div`
+  max-width: 425px;
+  width: 100%;
+  height: 100%;
+  margin: 0 auto;
+`;
+
+export default Layout;

--- a/src/components/ProgressBar.jsx
+++ b/src/components/ProgressBar.jsx
@@ -1,7 +1,10 @@
 import React from "react";
 import styled from "styled-components";
 
-const ProgressBar = ({ progress }) => {
+const ProgressBar = ({ curIdx, maxIdx }) => {
+  const progress = (curIdx / maxIdx) * 100;
+  console.log("curIdx", curIdx, "maxIdx", maxIdx, "progress", progress);
+
   return (
     <Container>
       <Progress width={`${progress}%`}></Progress>

--- a/src/components/ProgressBar.jsx
+++ b/src/components/ProgressBar.jsx
@@ -17,7 +17,7 @@ const Container = styled.div`
   border-radius: 5px;
   overflow: hidden;
   box-shadow: 0 2px 5px rgba(0, 0, 0, 0.1);
-  margin: 1rem 2rem;
+  margin: 2rem;
 `;
 
 const Progress = styled.div`

--- a/src/components/onboarding/MbtiForm.jsx
+++ b/src/components/onboarding/MbtiForm.jsx
@@ -1,22 +1,36 @@
 import styled from "styled-components";
 import React, { useState, useEffect } from "react";
 import MbtiContainer from "./MbtiContainer";
+import { useOnboardingStore } from "../../store/useOnboardingStore";
 
 const MbtiForm = () => {
   const [mbti, setMbti] = useState([null, null, null, null]);
   const [isMbtiValid, setIsMbtiValid] = useState(false);
   const [value, setValue] = useState(null);
 
+  const { setNav, setDisable } = useOnboardingStore((state) => ({
+    setNav: state.setNav,
+    setDisable: state.setDisable,
+  }));
+
+  useEffect(() => {
+    setIsMbtiValid(false);
+  }, []);
+
   useEffect(() => {
     const allSelected = mbti.every((e) => e !== null);
     setIsMbtiValid(allSelected);
-  }, [mbti]);
+    if (isMbtiValid) {
+      setNav("/onboarding/interest-info");
+      setDisable(false);
+      console.log("mbtivalid");
+    }
+  }, [mbti, isMbtiValid]);
 
   const handleClick = (idx, value) => {
     const selections = [...mbti];
     selections[idx] = value;
     setMbti(selections);
-    console.log();
   };
 
   return (

--- a/src/components/onboarding/NextButton.jsx
+++ b/src/components/onboarding/NextButton.jsx
@@ -1,8 +1,15 @@
 import React from "react";
 import styled from "styled-components";
+import { useOnboardingStore } from "../../store/useOnboardingStore";
 
 const NextButton = ({ onClick }) => {
-  return <Button onClick={onClick}>다음</Button>;
+  const disable = useOnboardingStore((state) => state.disable);
+
+  return (
+    <Button onClick={onClick} disabled={disable}>
+      다음
+    </Button>
+  );
 };
 
 export default NextButton;
@@ -14,7 +21,7 @@ const Button = styled.button`
   padding: 15px;
   margin-top: 15px;
   color: white;
-  background-color: #d9d9d9;
+  background-color: ${({ disabled }) => (disabled ? "#d9d9d9" : "#10D99B")};
   border: none;
   border-radius: 50px;
   cursor: pointer;

--- a/src/components/onboarding/PersonalInfoForm.jsx
+++ b/src/components/onboarding/PersonalInfoForm.jsx
@@ -1,5 +1,6 @@
 import React, { useState, useRef, useEffect } from "react";
 import styled from "styled-components";
+import { useOnboardingStore } from "../../store/useOnboardingStore";
 
 const PersonalInfoForm = () => {
   const [inputs, setInputs] = useState(["", "", "", "", "", ""]);
@@ -9,7 +10,15 @@ const PersonalInfoForm = () => {
   const [isBirthValid, setIsBirthValid] = useState(true);
   const [isNickNameValid, setisNickNameValid] = useState(true);
   const [isFormValid, setIsFormValid] = useState(false);
-  //-> zustand 사용해서 next button에 전달하여 버튼 활성화 예정
+
+  const { setNav, setDisable } = useOnboardingStore((state) => ({
+    setNav: state.setNav,
+    setDisable: state.setDisable,
+  }));
+
+  useEffect(() => {
+    setIsFormValid(false);
+  }, []);
 
   // 닉네임(공백,특수문자) 유효성, 성별 not null, 생년월일 유효성 검사
   // 폼 전체에 대한 유효성 검사를 위해 useEffect deps 사용
@@ -18,8 +27,12 @@ const PersonalInfoForm = () => {
     const isValid =
       isNickNameValid && isBirthValid && gender !== null && allInputsFilled;
     setIsFormValid(isValid);
-    console.log(`isalid? : ${isFormValid}`);
-  }, [inputs, isNickNameValid, isBirthValid, gender]);
+    if (isFormValid) {
+      setNav("/onboarding/mbti-info");
+      setDisable(false);
+      console.log("form valid");
+    }
+  }, [inputs, isNickNameValid, isBirthValid, gender, isFormValid]);
 
   const handleGenderClick = (buttonName) => {
     setGender((prevGender) => (prevGender === buttonName ? null : buttonName));

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -1,3 +1,5 @@
+import styled from "styled-components";
+
 const Home = () => {
   return <h1>HELLO WORLD!</h1>;
 };

--- a/src/pages/onboarding/InterestInfo.jsx
+++ b/src/pages/onboarding/InterestInfo.jsx
@@ -1,6 +1,5 @@
 import React from "react";
 import styled from "styled-components";
-import NextButton from "../../components/onboarding/NextButton";
 
 /**
  * entry point
@@ -37,7 +36,6 @@ const InterestInfo = () => {
     <Container>
       <Header />
       <Content objectList={objectList} />
-      <NextButton />
     </Container>
   );
 };

--- a/src/pages/onboarding/Onboarding.jsx
+++ b/src/pages/onboarding/Onboarding.jsx
@@ -1,24 +1,53 @@
-import React, { useState } from "react";
-import { Outlet } from "react-router-dom";
+import React, { useEffect, useState } from "react";
+import { Outlet, useLocation } from "react-router-dom";
 import styled from "styled-components";
 import { useNavigate } from "react-router-dom";
 import ProgressBar from "../../components/ProgressBar";
 import NextButton from "../../components/onboarding/NextButton";
+import { useOnboardingStore } from "../../store/useOnboardingStore";
 
 const Onboarding = () => {
+  const { disable, address, setDisable } = useOnboardingStore((state) => ({
+    address: state.address,
+    disable: state.disable,
+    setDisable: state.setDisable,
+  }));
   const nav = useNavigate();
-
+  const location = useLocation();
   const [progress, setProgress] = useState(25);
 
-  const handleClick = () => {
-    setProgress((prev) => progress + 25);
+  useEffect(() => {
+    setDisable(true);
+    switch (location.pathname) {
+      case "/onboarding/personal-info":
+        setProgress(25);
+        break;
+      case "/onboarding/mbti-info":
+        setProgress(50);
+        break;
+      case "/onboarding/interest-info":
+        setProgress(75);
+        break;
+      case "/onboarding/terms-agreement":
+        setProgress(100);
+        break;
+      default:
+        setProgress(25);
+    }
+  }, [location, setDisable]);
+
+  const handleClick = (address) => {
+    if (!disable) {
+      setProgress((prev) => progress + 25);
+      nav(address);
+    }
   };
 
   return (
     <OnboardingContainer>
       <ProgressBar progress={progress} />
       <Outlet />
-      <NextButton onClick={handleClick} />
+      <NextButton onClick={() => handleClick(address)} />
     </OnboardingContainer>
   );
 };
@@ -28,9 +57,8 @@ export default Onboarding;
 const OnboardingContainer = styled.div`
   display: flex;
   flex-direction: column;
-  width: 100vw;
-  height: 100vh;
-  min-width: 375px;
+  width: 100%;
+  height: 100%;
   align-items: center;
   justify-content: center;
   background: #fff;

--- a/src/pages/onboarding/Onboarding.jsx
+++ b/src/pages/onboarding/Onboarding.jsx
@@ -14,38 +14,38 @@ const Onboarding = () => {
   }));
   const nav = useNavigate();
   const location = useLocation();
-  const [progress, setProgress] = useState(25);
+  const [curIdx, setIdx] = useState(1);
+  const maxIdx = 4;
 
   useEffect(() => {
     setDisable(true);
     switch (location.pathname) {
       case "/onboarding/personal-info":
-        setProgress(25);
+        setIdx(1);
         break;
       case "/onboarding/mbti-info":
-        setProgress(50);
+        setIdx(2);
         break;
       case "/onboarding/interest-info":
-        setProgress(75);
+        setIdx(3);
         break;
       case "/onboarding/terms-agreement":
-        setProgress(100);
+        setIdx(4);
         break;
       default:
-        setProgress(25);
+        setIdx(1);
     }
   }, [location, setDisable]);
 
   const handleClick = (address) => {
     if (!disable) {
-      setProgress((prev) => progress + 25);
       nav(address);
     }
   };
 
   return (
     <OnboardingContainer>
-      <ProgressBar progress={progress} />
+      <ProgressBar curIdx={curIdx} maxIdx={maxIdx} />
       <Outlet />
       <NextButton onClick={() => handleClick(address)} />
     </OnboardingContainer>

--- a/src/pages/onboarding/TermsAgreement.jsx
+++ b/src/pages/onboarding/TermsAgreement.jsx
@@ -1,13 +1,11 @@
 import React from "react";
 import styled from "styled-components";
-import NextButton from "../../components/onboarding/NextButton";
 
 const TermsAgreement = () => {
   return (
     <Container>
       <Header />
       <Content />
-      <NextButton />
     </Container>
   );
 };
@@ -71,6 +69,7 @@ const ContentContainer = styled.div`
   justify-content: space-around;
   height: 100%;
   padding: 20px;
+  gap: 20px;
 `;
 
 const TermContainer = styled.div`

--- a/src/store/useOnboardingStore.jsx
+++ b/src/store/useOnboardingStore.jsx
@@ -1,0 +1,8 @@
+import { create } from "zustand";
+
+export const useOnboardingStore = create((set) => ({
+  address: "",
+  disable: true,
+  setNav: (page) => set({ address: page }),
+  setDisable: (disable) => set({ disable }),
+}));


### PR DESCRIPTION
## Issue number
#16 
## Summary & Screenshots
<img width="462" alt="image" src="https://github.com/user-attachments/assets/0fdfc962-1e7a-470c-a818-751f8722f7dc">

## Describe your changes (option)
- router 감싸는 layout 컴포넌트 추가
    - max-width : 425px
- 조건 충족시 다음 버튼 활성화
    - zustand store 사용
- useLocation훅 사용해서 location별로 progress bar width 설정되도록 변경

## Things to consider (option)
- 다음 버튼 활성화시 컴포넌트 별로 반복되는 로직이 많아서 훅으로 뺄 수 있으면 빼보려고 합니다
- 이제 page들에서 max-width 설정 없이 100%로 하면 될 것 같습니다!
- 조언해주시면 감사합니다🫡